### PR TITLE
[Core] Implement special escape functions (through `ParseSingleUnsafe`)

### DIFF
--- a/Core/Implementation/RoslynContext.cs
+++ b/Core/Implementation/RoslynContext.cs
@@ -282,18 +282,6 @@ namespace Core
                 ParseSingleUnsafe(input);
             else ParseSingle(input);
         }
-        internal void ParseUnsafe(string input, string currentScriptFile, string nugetRepoIdentifier)
-        {
-            if (ImportModuleRegex().IsMatch(input))
-                ImportModule(input, nugetRepoIdentifier);
-            else if (IncludeScriptRegex().IsMatch(input))
-                IncludeScript(input, currentScriptFile, nugetRepoIdentifier);
-            else if (HelpItemRegex().IsMatch(input))
-                HelpItem(input);
-            else if (IsolatedScriptLineForSpecialFunctionsRegex().IsMatch(input))
-                ParseSingleUnsafe(input);
-            else ParseSingleUnsafe(input);
-        }
         internal object Evaluate(string expression, string currentScriptFile, string nugetRepoIdentifier)
         {
             if (ImportModuleRegex().IsMatch(expression))

--- a/Core/Interpreter.cs
+++ b/Core/Interpreter.cs
@@ -141,7 +141,7 @@ namespace Core
                 if (!currentLineIsInBlockComment &&
                     (RoslynContext.ImportModuleRegex().IsMatch(line)
                     || RoslynContext.IncludeScriptRegex().IsMatch(line)
-                    || RoslynContext.ParseScriptRegex().IsMatch(line)   // Remark-cz: This means that our `Parse()` function when executed inside a script can only be on its own line
+                    || RoslynContext.IsolatedScriptLineForSpecialFunctionsRegex().IsMatch(line)   // Remark-cz: This means that our `Parse()` function etc. when executed inside a script can only be on its own line
                     || RoslynContext.HelpItemRegex().IsMatch(line)))
                 {
                     if (scriptBuilder.Length != 0)

--- a/Core/Interpreter.cs
+++ b/Core/Interpreter.cs
@@ -28,7 +28,7 @@ namespace Core
             * v0.4.0: Remove `#` style line comment (potential conflict with #region due to how we parse it).
             * v0.5.0: Add add-on standard library CentralSnippets. Implement construct `Pull()` and `Preview()`.
             * v0.5.1: Enhance Roslyn Context with script record.
-            * v0.5.2: Implement `ParseUnsafe()`.
+            * v0.5.2: Implement language level `Parse()` and `Pull()` handling.
             """;
         #endregion
 
@@ -75,8 +75,6 @@ namespace Core
         }
         public void Parse(string script)
             => Context.Parse(script, ScriptFile, NugetRepoIdentifier);
-        internal void ParseUnsafe(string script)
-            => Context.ParseUnsafe(script, ScriptFile, NugetRepoIdentifier);
         public object Evaluate(string expression)
             => Context.Evaluate(expression, ScriptFile, NugetRepoIdentifier);
         public string GetState()

--- a/Core/Utilities/Construct.cs
+++ b/Core/Utilities/Construct.cs
@@ -25,15 +25,6 @@ namespace Core.Utilities
 
         #region Runtime Parsing
         internal static Interpreter CurrentInterpreter;
-        /// <summary>
-        /// Compared to Parse, this will ignore context lock
-        /// </summary>
-        public static void ParseUnsafe(string script)
-        {
-            if (CurrentInterpreter != null)
-                CurrentInterpreter.ParseUnsafe(script);
-            else throw new ApplicationException("Interpreter is not initialized.");
-        }
         public static void Parse(string script)
         {
             if (CurrentInterpreter != null)

--- a/StandardLibraries/CentralSnippets/Main.cs
+++ b/StandardLibraries/CentralSnippets/Main.cs
@@ -20,7 +20,7 @@ namespace CentralSnippets
             string content = GetContent(SnippetsHostSite, SnippetsRootFolder, snippetIdentifier, disableSSL);
             // Remark-cz: We need to split script first to allow handling of specific Pure constructs (e.g. Import)
             foreach(var segment in Interpreter.SplitScripts(content))
-                Core.Utilities.Construct.ParseUnsafe(segment);
+                Core.Utilities.Construct.Parse(segment);
         }
         public static void Preview(string snippetIdentifier, bool disableSSL = false)
         {

--- a/UnitTests/CoreTest/ScriptParsingTest.cs
+++ b/UnitTests/CoreTest/ScriptParsingTest.cs
@@ -208,6 +208,20 @@ namespace CoreTest
             Assert.Equal((expected + Environment.NewLine + secondScript).Replace("\r\n", "\n"), currentState);
         }
         [Fact]
+        public void ParseUnsafeShouldNotBeRecorded()
+        {
+            Interpreter interpreter = new(null, null, null, null, null);
+            interpreter.Start();
+
+            Core.Utilities.Construct.ParseUnsafe(""""
+                WriteLine("Hello World.");
+                """");
+
+            string expected = "string[] Arguments = Array.Empty<string>();";
+            string currentState = interpreter.GetState().Replace("\r\n", "\n");
+            Assert.Equal(expected, currentState);
+        }
+        [Fact]
         public void ParsingScriptInsideInterpreterShouldNOTWork2()
         {
             Interpreter interpreter = new(null, null, null, null, null);

--- a/UnitTests/CoreTest/ScriptParsingTest.cs
+++ b/UnitTests/CoreTest/ScriptParsingTest.cs
@@ -172,6 +172,11 @@ namespace CoreTest
             Core.Utilities.Construct.Parse(""""
                 Parse("WriteLine(5)");
                 """");
+
+            Assert.Equal("""
+                string[] Arguments = Array.Empty<string>();
+                WriteLine(5)
+                """.Replace("\r\n", "\n"), interpreter.GetState().Replace("\r\n", "\n"));
         }
     }
 }

--- a/UnitTests/CoreTest/ScriptParsingTest.cs
+++ b/UnitTests/CoreTest/ScriptParsingTest.cs
@@ -151,78 +151,7 @@ namespace CoreTest
             Assert.Equal(expected + script.Replace("Import(Markdig)", string.Empty).Replace("\r\n", "\n"), interpreter.GetState().Replace("\r\n", "\n"));
         }
         [Fact]
-        public void ParsingScriptInsideInterpreterShouldNOTWork()
-        {
-            Interpreter interpreter = new(null, null, null, null, null);
-            interpreter.Start();
-
-            Core.Utilities.Construct.Parse(""""
-                using Core;
-                string script = """
-                    Import(Markdig)
-
-                    string Build(string markdown)
-                    {
-                        var pipeline = new MarkdownPipelineBuilder().UseAdvancedExtensions().Build();
-                        var document = Markdown.ToHtml("This is a text with some *emphasis*", pipeline);
-                        return document;
-                    }
-                    """;
-                var segments = Interpreter.SplitScripts(script);
-                // The first pass will seem to work but NOT really because state is already messed up
-                foreach (var a in segments)
-                    ParseUnsafe(a);
-                """");
-
-            string expected = """"
-                string[] Arguments = Array.Empty<string>();
-                using Core;
-                string script = """
-                    Import(Markdig)
-                
-                    string Build(string markdown)
-                    {
-                        var pipeline = new MarkdownPipelineBuilder().UseAdvancedExtensions().Build();
-                        var document = Markdown.ToHtml("This is a text with some *emphasis*", pipeline);
-                        return document;
-                    }
-                    """;
-                var segments = Interpreter.SplitScripts(script);
-                // The first pass will seem to work but NOT really because state is already messed up
-                foreach (var a in segments)
-                    ParseUnsafe(a);
-                """".Replace("\r\n", "\n");
-            string currentState = interpreter.GetState().Replace("\r\n", "\n");
-            Assert.Equal(expected, currentState);
-
-            // Remark-cz: At this time, at the end of previous state, the namespace isn't really imported
-            string secondScript = """"
-                // This second pass will not fail but also not cause the segment to be included in the state.
-                // Because the `Import` construct will think the library is imported so won't import it again, 
-                // but since the namespace isn't really imported, so it will fail during execution
-                foreach (var a in segments)
-                    ParseUnsafe(a);
-                """";
-            Core.Utilities.Construct.Parse(secondScript);
-            currentState = interpreter.GetState().Replace("\r\n", "\n");
-            Assert.Equal((expected + Environment.NewLine + secondScript).Replace("\r\n", "\n"), currentState);
-        }
-        [Fact]
-        public void ParseUnsafeShouldNotBeRecorded()
-        {
-            Interpreter interpreter = new(null, null, null, null, null);
-            interpreter.Start();
-
-            Core.Utilities.Construct.ParseUnsafe(""""
-                WriteLine("Hello World.");
-                """");
-
-            string expected = "string[] Arguments = Array.Empty<string>();";
-            string currentState = interpreter.GetState().Replace("\r\n", "\n");
-            Assert.Equal(expected, currentState);
-        }
-        [Fact]
-        public void ParsingScriptInsideInterpreterShouldNOTWork2()
+        public void ParsingScriptInsideInterpreterShouldNOTWorkWhenSyntaxDoesntPermit()
         {
             Interpreter interpreter = new(null, null, null, null, null);
             interpreter.Start();
@@ -230,9 +159,19 @@ namespace CoreTest
             Assert.Throws<RecursiveParsingException>(() =>
             {
                 Core.Utilities.Construct.Parse(""""
-                Parse("WriteLine(5)");
+                int a = 5; Parse("WriteLine(5)");
                 """");
             });
+        }
+        [Fact]
+        public void ParsingScriptInsideInterpreterAsSingleLineShouldWorkOutOfBox()
+        {
+            Interpreter interpreter = new(null, null, null, null, null);
+            interpreter.Start();
+
+            Core.Utilities.Construct.Parse(""""
+                Parse("WriteLine(5)");
+                """");
         }
     }
 }


### PR DESCRIPTION
Implements special handling for `Parse()` to allow state discontinuity: when `Parse()` is executed on its own, we will "dismiss" the content being parsed and effectively "insert" the states from execution of the interpreted script. This is illustrated in the commit https://github.com/Pure-the-Language/Pure/pull/22/commits/8b610fc138528656ae34cf51f0214c5dda30a6a8.

- This setup allows using standard C# to implement certain functionalities on the parser/interpreter level while not really interfering with usual state continuity.